### PR TITLE
Add Meta AI (Muse Spark) as an API provider

### DIFF
--- a/textlingo-desktop/agent-worker/src/provider/resolveProvider.ts
+++ b/textlingo-desktop/agent-worker/src/provider/resolveProvider.ts
@@ -39,11 +39,13 @@ const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
 const SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1";
 const PROVIDER_302AI_BASE_URL = "https://api.302.ai/v1";
+const META_BASE_URL = "https://api.meta.ai/v1";
 const OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const LMSTUDIO_BASE_URL = "http://127.0.0.1:1234/v1";
 const LEGACY_KIMI_PROVIDER = "moonshot";
 const KIMI_CHINA_PROVIDER = "moonshot-cn";
 const KIMI_GLOBAL_PROVIDER = "moonshot-global";
+const META_PROVIDER = "meta";
 
 function isKimiProvider(provider: string) {
   return (
@@ -74,6 +76,9 @@ function resolveDefaultBaseUrl(provider: string) {
       return "https://api.moonshot.cn/v1";
     case KIMI_GLOBAL_PROVIDER:
       return "https://api.moonshot.ai/v1";
+    case META_PROVIDER:
+    case "meta":
+      return META_BASE_URL;
     default:
       return undefined;
   }
@@ -111,6 +116,7 @@ export function resolveRuntimeProvider(config: RuntimeModelConfig): ResolvedRunt
       "302ai",
       "ollama",
       "lmstudio",
+      "meta",
     ].includes(provider) ||
       isKimiProvider(provider)) &&
     baseUrl

--- a/textlingo-desktop/src-tauri/src/agent_worker.rs
+++ b/textlingo-desktop/src-tauri/src/agent_worker.rs
@@ -230,6 +230,7 @@ pub enum RuntimeProviderConfig {
 
 const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const META_BASE_URL: &str = "https://api.meta.ai/v1";
 const OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434/v1";
 const LMSTUDIO_BASE_URL: &str = "http://127.0.0.1:1234/v1";
 
@@ -553,6 +554,7 @@ pub fn default_base_url(provider: &str) -> Option<&'static str> {
         "deepseek" => Some("https://api.deepseek.com/v1"),
         "siliconflow" => Some("https://api.siliconflow.cn/v1"),
         "302ai" => Some("https://api.302.ai/v1"),
+        "meta" => Some(META_BASE_URL),
         "ollama" => Some(OLLAMA_BASE_URL),
         "lmstudio" => Some(LMSTUDIO_BASE_URL),
         _ if moonshot_base_url(provider).is_some() => moonshot_base_url(provider),
@@ -595,6 +597,7 @@ pub fn resolve_runtime_provider_config(config: &ModelConfig) -> RuntimeProviderC
         "302ai",
         "ollama",
         "lmstudio",
+        "meta",
     ]
     .contains(&provider.as_str())
         || moonshot_base_url(&provider).is_some()

--- a/textlingo-desktop/src-tauri/src/ai_service.rs
+++ b/textlingo-desktop/src-tauri/src/ai_service.rs
@@ -15,6 +15,7 @@ const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1/chat/completions"
 const DEEPSEEK_API_URL: &str = "https://api.deepseek.com/v1/chat/completions";
 const SILICONFLOW_API_URL: &str = "https://api.siliconflow.cn/v1/chat/completions";
 const API_302AI_URL: &str = "https://api.302.ai/v1/chat/completions";
+const META_API_URL: &str = "https://api.meta.ai/v1/chat/completions";
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 
 pub struct AIService {
@@ -76,6 +77,7 @@ impl AIService {
             "deepseek" => DEEPSEEK_API_URL.to_string(),
             "siliconflow" => SILICONFLOW_API_URL.to_string(),
             "302ai" => API_302AI_URL.to_string(),
+            "meta" => META_API_URL.to_string(),
             "google" | "google-ai-studio" => format!(
                 "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent",
                 self.model.strip_prefix("models/").unwrap_or(&self.model)

--- a/textlingo-desktop/src/components/features/SettingsDialog.test.tsx
+++ b/textlingo-desktop/src/components/features/SettingsDialog.test.tsx
@@ -171,4 +171,175 @@ describe("SettingsDialog", () => {
       );
     });
   });
+
+  it("syncs Meta and saves first synced model without manual dropdown change", async () => {
+    const syncedMeta = { data: [{ id: "rl-muse-spark-1-2-playground" }, { id: "muse-spark-1.1" }] };
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => syncedMeta } as any);
+    vi.stubGlobal("fetch", fetchMock);
+
+    invokeMock.mockImplementation((command: string, args?: any) => {
+      if (command === "get_config") {
+        return Promise.resolve({
+          model_configs: [
+            { id: "c1", name: "Meta", api_key: "k", api_provider: "meta", model: "muse-spark-1.2", is_default: true },
+          ],
+          target_language: "zh-CN",
+          interface_language: "en",
+          prompt_features: [],
+        });
+      }
+      if (command === "save_model_config") return Promise.resolve(args.config);
+      return Promise.resolve("ok");
+    });
+
+    render(<SettingsDialog isOpen onClose={vi.fn()} onSave={vi.fn()} />);
+
+    // open edit form for the existing config
+    const editBtn = await screen.findByTitle("settings.editConfig");
+    await userEvent.click(editBtn);
+
+    // provider is meta, sync button should be visible now
+    const syncBtn = await screen.findByTitle("settings.syncModelsTooltip");
+    await userEvent.click(syncBtn);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    // after sync, the model select should have been auto-updated to first synced
+    // because muse-spark-1.2 is not in synced list
+    await waitFor(() => expect((screen.getByDisplayValue("rl-muse-spark-1-2-playground") as HTMLSelectElement).value).toBe("rl-muse-spark-1-2-playground"));
+
+    await userEvent.click(screen.getByText("settings.saveConfig"));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith(
+        "save_model_config",
+        expect.objectContaining({ config: expect.objectContaining({ model: "rl-muse-spark-1-2-playground", api_provider: "meta" }) }),
+      ),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not apply late Meta sync after switching provider", async () => {
+    let resolveFetch: (v: any) => void = () => {};
+    const fetchPromise = new Promise<any>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn().mockReturnValue(fetchPromise);
+    vi.stubGlobal("fetch", fetchMock);
+
+    invokeMock.mockImplementation((command: string, args?: any) => {
+      if (command === "get_config") {
+        return Promise.resolve({
+          model_configs: [
+            { id: "c1", name: "Meta", api_key: "k", api_provider: "meta", model: "muse-spark-1.2", is_default: true },
+          ],
+          target_language: "zh-CN",
+          interface_language: "en",
+          prompt_features: [],
+        });
+      }
+      if (command === "save_model_config") return Promise.resolve(args.config);
+      return Promise.resolve("ok");
+    });
+
+    render(<SettingsDialog isOpen onClose={vi.fn()} onSave={vi.fn()} />);
+
+    const editBtn = await screen.findByTitle("settings.editConfig");
+    await userEvent.click(editBtn);
+
+    const syncBtn = await screen.findByTitle("settings.syncModelsTooltip");
+    await userEvent.click(syncBtn);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain("api.meta.ai");
+
+    // switch provider to openai before fetch resolves - find provider select by value
+    const allSelects = document.querySelectorAll("select");
+    const providerSelect = Array.from(allSelects).find(s => (s as HTMLSelectElement).value === "meta") as HTMLSelectElement;
+    expect(providerSelect).toBeTruthy();
+    fireEvent.change(providerSelect, { target: { value: "openai" } });
+
+    // now resolve the Meta fetch late
+    resolveFetch({ ok: true, json: async () => ({ data: [{ id: "rl-muse-spark-1-2-playground" }] }) } as any);
+
+    // give React a tick to process the late sync - provider should stay openai
+    await waitFor(() => {
+      const updatedProviderSelect = Array.from(document.querySelectorAll("select")).find(s => (s as HTMLSelectElement).value === "openai") as HTMLSelectElement;
+      expect(updatedProviderSelect).toBeTruthy();
+    });
+    // model should still be openai default (gpt-4o), not overwritten to meta's rl-...
+    await waitFor(() => {
+      const modelSelect = Array.from(document.querySelectorAll("select")).find(s => (s as HTMLSelectElement).value === "gpt-4o") as HTMLSelectElement;
+      expect(modelSelect).toBeTruthy();
+    });
+    // ensure late meta result did not inject rl-... into openai's model list
+    expect(document.body.textContent).not.toContain("rl-muse-spark-1-2-playground");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("entering API key and immediately saving Meta without sync uses playground default", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [] }) } as any);
+    vi.stubGlobal("fetch", fetchMock);
+
+    invokeMock.mockImplementation((command: string, args?: any) => {
+      if (command === "get_config") {
+        return Promise.resolve({
+          model_configs: [],
+          target_language: "zh-CN",
+          interface_language: "en",
+          prompt_features: [],
+        });
+      }
+      if (command === "save_model_config") return Promise.resolve(args.config);
+      return Promise.resolve("ok");
+    });
+
+    render(<SettingsDialog isOpen onClose={vi.fn()} onSave={vi.fn()} />);
+
+    // start new config
+    const addBtn = await screen.findByText("settings.addConfig");
+    await userEvent.click(addBtn);
+
+    // switch provider to meta - find provider select by its initial openai value
+    let providerSelect = document.querySelectorAll("select")[0] as HTMLSelectElement;
+    // Initially provider is openai after startNewConfig, switch to meta
+    fireEvent.change(providerSelect, { target: { value: "meta" } });
+
+    // after switch, model should be playground default without needing sync
+    await waitFor(() => {
+      const modelSelect = document.querySelectorAll("select")[1] as HTMLSelectElement;
+      expect(modelSelect.value).toBe("rl-muse-spark-1-2-playground");
+    });
+
+    // fill required fields: config name and API key
+    const nameInput = screen.getByPlaceholderText("settings.configNamePlaceholder") as HTMLInputElement;
+    await userEvent.type(nameInput, "My Meta");
+
+    const apiKeyInput = screen.getByPlaceholderText("settings.apiKeyPlaceholder") as HTMLInputElement;
+    await userEvent.type(apiKeyInput, "test-key-123");
+
+    // blur triggers auto-sync (isAuto=true) - fetch may be called, but manual sync not required
+    // Do not assert fetch not called; verify save works without manual sync click
+    const syncBtn = screen.getByTitle("settings.syncModelsTooltip");
+    expect(syncBtn).toBeInTheDocument();
+    // ensure we did NOT manually click sync
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("api.meta.ai/v1/models"), expect.anything());
+
+    await userEvent.click(screen.getByText("settings.saveConfig"));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith(
+        "save_model_config",
+        expect.objectContaining({
+          config: expect.objectContaining({
+            api_provider: "meta",
+            model: "rl-muse-spark-1-2-playground",
+            api_key: "test-key-123",
+          }),
+        }),
+      ),
+    );
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/textlingo-desktop/src/components/features/SettingsDialog.tsx
+++ b/textlingo-desktop/src/components/features/SettingsDialog.tsx
@@ -19,6 +19,11 @@ import {
   LEGACY_KIMI_PROVIDER,
   normalizeKimiProvider,
 } from "../../lib/kimiProvider";
+import {
+  getMetaModelsUrl,
+  isMetaProvider,
+  META_PROVIDER,
+} from "../../lib/metaProvider";
 
 interface OpenRouterModel {
   id: string;
@@ -31,13 +36,14 @@ interface OpenRouterModel {
   };
 }
 
-const SUPPORTED_PROVIDERS = ["openai", "anthropic", "openrouter", "deepseek", "siliconflow", "302ai", "google", "google-ai-studio", KIMI_CHINA_PROVIDER, KIMI_GLOBAL_PROVIDER, "openai-compatible", "ollama", "lmstudio"] as const;
+const SUPPORTED_PROVIDERS = ["openai", "anthropic", "openrouter", "deepseek", "siliconflow", "302ai", "google", "google-ai-studio", KIMI_CHINA_PROVIDER, KIMI_GLOBAL_PROVIDER, META_PROVIDER, "openai-compatible", "ollama", "lmstudio"] as const;
 
 // Default base URLs for local providers
 const DEFAULT_BASE_URLS: Record<string, string> = {
   "openai": "https://api.openai.com/v1",
   "ollama": "http://localhost:11434/v1",
   "lmstudio": "http://localhost:1234/v1",
+  "meta": "https://api.meta.ai/v1",
 };
 
 const DEFAULT_BATCH_TRANSLATION_CONCURRENCY = 3;
@@ -222,6 +228,11 @@ const DEFAULT_MODELS = {
     { value: "moonshot-v1-32k", labelKey: "settings.models.moonshot.moonshot-v1-32k" },
     { value: "moonshot-v1-8k", labelKey: "settings.models.moonshot.moonshot-v1-8k" },
   ],
+  [META_PROVIDER]: [
+    { value: "muse-spark-1.2", labelKey: "settings.models.meta.muse-spark-1.2" },
+    { value: "muse-spark-1.1", labelKey: "settings.models.meta.muse-spark-1.1" },
+    { value: "muse-spark-1.2-contributor", labelKey: "settings.models.meta.muse-spark-1.2-contributor" },
+  ],
   ollama: [
     { value: "qwen2.5:7b-instruct", labelKey: "settings.models.ollama.qwen2_5_7b_instruct" },
     { value: "llama3.1:8b-instruct", labelKey: "settings.models.ollama.llama3_1_8b_instruct" },
@@ -279,6 +290,7 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
     [LEGACY_KIMI_PROVIDER]: DEFAULT_MODELS[LEGACY_KIMI_PROVIDER].map(m => ({ value: m.value, label: t(m.labelKey) })),
     [KIMI_CHINA_PROVIDER]: DEFAULT_MODELS[KIMI_CHINA_PROVIDER].map(m => ({ value: m.value, label: t(m.labelKey) })),
     [KIMI_GLOBAL_PROVIDER]: DEFAULT_MODELS[KIMI_GLOBAL_PROVIDER].map(m => ({ value: m.value, label: t(m.labelKey) })),
+    [META_PROVIDER]: DEFAULT_MODELS[META_PROVIDER].map(m => ({ value: m.value, label: t(m.labelKey) })),
     ollama: DEFAULT_MODELS.ollama.map(m => ({ value: m.value, label: t(m.labelKey) })),
   });
   const [modelFilter, setModelFilter] = useState("");
@@ -660,7 +672,7 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
 
     const provider = editingConfig.api_provider;
     // Ensure provider is defined and valid
-    if (!provider || !["openrouter", "openai", "openai-compatible", "deepseek", "siliconflow", "302ai", "google", "google-ai-studio", KIMI_CHINA_PROVIDER, KIMI_GLOBAL_PROVIDER, LEGACY_KIMI_PROVIDER, "ollama"].includes(provider)) {
+    if (!provider || !["openrouter", "openai", "openai-compatible", "deepseek", "siliconflow", "302ai", "google", "google-ai-studio", KIMI_CHINA_PROVIDER, KIMI_GLOBAL_PROVIDER, LEGACY_KIMI_PROVIDER, META_PROVIDER, "ollama"].includes(provider)) {
       if (!isAuto) setSyncError(t("settings.syncErrors.providerNotSupported") || "Provider not supported for sync");
       return;
     }
@@ -720,6 +732,12 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
         };
       } else if (isKimiProvider(provider)) {
         url = getKimiModelsUrl(provider) || "";
+        headers = {
+          "Authorization": `Bearer ${editingConfig.api_key}`,
+          "Content-Type": "application/json",
+        };
+      } else if (isMetaProvider(provider)) {
+        url = getMetaModelsUrl(provider) || "";
         headers = {
           "Authorization": `Bearer ${editingConfig.api_key}`,
           "Content-Type": "application/json",
@@ -800,6 +818,14 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
             .filter((m: { value: string }) => m.value.includes("gemini"));
         }
       } else if (isKimiProvider(provider)) {
+        if (data.data && Array.isArray(data.data)) {
+          syncedModels = data.data
+            .map((m: any) => ({
+              value: m.id,
+              label: m.id,
+            }));
+        }
+      } else if (isMetaProvider(provider)) {
         if (data.data && Array.isArray(data.data)) {
           syncedModels = data.data
             .map((m: any) => ({

--- a/textlingo-desktop/src/components/features/SettingsDialog.tsx
+++ b/textlingo-desktop/src/components/features/SettingsDialog.tsx
@@ -229,6 +229,7 @@ const DEFAULT_MODELS = {
     { value: "moonshot-v1-8k", labelKey: "settings.models.moonshot.moonshot-v1-8k" },
   ],
   [META_PROVIDER]: [
+    { value: "rl-muse-spark-1-2-playground", labelKey: "settings.models.meta.rl-muse-spark-1-2-playground" },
     { value: "muse-spark-1.2", labelKey: "settings.models.meta.muse-spark-1.2" },
     { value: "muse-spark-1.1", labelKey: "settings.models.meta.muse-spark-1.1" },
     { value: "muse-spark-1.2-contributor", labelKey: "settings.models.meta.muse-spark-1.2-contributor" },
@@ -727,9 +728,6 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
           "Authorization": `Bearer ${editingConfig.api_key}`,
           "Content-Type": "application/json",
         };
-        headers = {
-          "Content-Type": "application/json",
-        };
       } else if (isKimiProvider(provider)) {
         url = getKimiModelsUrl(provider) || "";
         headers = {
@@ -851,11 +849,15 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
           }));
         }
 
-        // If current model is not in list (e.g. initial setup), potentially select first one?
-        // Let's NOT auto-select to avoid overwriting user choice unless it's empty.
-        if (!editingConfig.model && syncedModels.length > 0) {
-          setEditingConfig(prev => ({ ...prev, model: syncedModels[0].value }));
-        }
+        setEditingConfig(prev => {
+          if (!prev || prev.api_provider !== provider) return prev as any;
+          const cur = prev.model;
+          const isValid = syncedModels.some(m => m.value === cur);
+          if (!cur || !isValid) {
+            return { ...prev, model: syncedModels[0].value };
+          }
+          return prev;
+        });
       }
 
     } catch (err) {
@@ -1210,7 +1212,7 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
                     <label className="block text-sm font-medium text-foreground">
                       {t("settings.model")}
                     </label>
-                    {(["openrouter", "openai", "deepseek", "google", "google-ai-studio", "302ai", "siliconflow", "ollama"].includes(editingConfig.api_provider || "") || isKimiProvider(editingConfig.api_provider || "")) && (
+                    {(["openrouter", "openai", "deepseek", "google", "google-ai-studio", "302ai", "siliconflow", "ollama"].includes(editingConfig.api_provider || "") || isKimiProvider(editingConfig.api_provider || "") || isMetaProvider(editingConfig.api_provider || "")) && (
                       <Button
                         type="button"
                         variant="ghost"
@@ -1243,7 +1245,7 @@ export function SettingsDialog({ isOpen, onClose, onSave }: SettingsDialogProps)
                         if (e.target.value === "__custom__") {
                           setUseCustomModel(true);
                         } else {
-                          setEditingConfig({ ...editingConfig, model: e.target.value });
+                          setEditingConfig(prev => ({ ...prev, model: e.target.value } as any));
                         }
                       }}
                     >

--- a/textlingo-desktop/src/lib/metaProvider.ts
+++ b/textlingo-desktop/src/lib/metaProvider.ts
@@ -1,0 +1,14 @@
+export const META_PROVIDER = "meta";
+
+export function isMetaProvider(provider: string): boolean {
+  return provider === META_PROVIDER;
+}
+
+export function getMetaBaseUrl(provider: string): string | null {
+  return isMetaProvider(provider) ? "https://api.meta.ai/v1" : null;
+}
+
+export function getMetaModelsUrl(provider: string): string | null {
+  const baseUrl = getMetaBaseUrl(provider);
+  return baseUrl ? `${baseUrl}/models` : null;
+}

--- a/textlingo-desktop/src/locales/en.json
+++ b/textlingo-desktop/src/locales/en.json
@@ -387,6 +387,7 @@
         "moonshot-v1-8k": "Moonshot v1 8k"
       },
       "meta": {
+        "rl-muse-spark-1-2-playground": "Muse Spark 1.2 Playground",
         "muse-spark-1.2": "Muse Spark 1.2",
         "muse-spark-1.1": "Muse Spark 1.1",
         "muse-spark-1.2-contributor": "Muse Spark 1.2 Contributor"

--- a/textlingo-desktop/src/locales/en.json
+++ b/textlingo-desktop/src/locales/en.json
@@ -324,6 +324,7 @@
       "moonshot": "Moonshot AI",
       "moonshot-cn": "Moonshot AI (Kimi China)",
       "moonshot-global": "Moonshot AI (Kimi Global)",
+      "meta": "Meta AI",
       "anthropic": "Anthropic (Claude)"
     },
     "baseUrl": "Base URL",
@@ -384,6 +385,11 @@
         "moonshot-v1-128k": "Moonshot v1 128k",
         "moonshot-v1-32k": "Moonshot v1 32k",
         "moonshot-v1-8k": "Moonshot v1 8k"
+      },
+      "meta": {
+        "muse-spark-1.2": "Muse Spark 1.2",
+        "muse-spark-1.1": "Muse Spark 1.1",
+        "muse-spark-1.2-contributor": "Muse Spark 1.2 Contributor"
       },
       "anthropic": {
         "claude-sonnet-4-6": "Claude Sonnet 4.6",

--- a/textlingo-desktop/src/locales/ja.json
+++ b/textlingo-desktop/src/locales/ja.json
@@ -377,6 +377,7 @@
         "moonshot-v1-8k": "Moonshot v1 8k"
       },
       "meta": {
+        "rl-muse-spark-1-2-playground": "Muse Spark 1.2 Playground",
         "muse-spark-1.2": "Muse Spark 1.2",
         "muse-spark-1.1": "Muse Spark 1.1",
         "muse-spark-1.2-contributor": "Muse Spark 1.2 Contributor"

--- a/textlingo-desktop/src/locales/ja.json
+++ b/textlingo-desktop/src/locales/ja.json
@@ -314,6 +314,7 @@
       "moonshot": "Moonshot AI",
       "moonshot-cn": "Moonshot AI (Kimi China)",
       "moonshot-global": "Moonshot AI (Kimi Global)",
+      "meta": "Meta AI",
       "anthropic": "Anthropic (Claude)"
     },
     "baseUrl": "ベースURL",
@@ -374,6 +375,11 @@
         "moonshot-v1-128k": "Moonshot v1 128k",
         "moonshot-v1-32k": "Moonshot v1 32k",
         "moonshot-v1-8k": "Moonshot v1 8k"
+      },
+      "meta": {
+        "muse-spark-1.2": "Muse Spark 1.2",
+        "muse-spark-1.1": "Muse Spark 1.1",
+        "muse-spark-1.2-contributor": "Muse Spark 1.2 Contributor"
       },
       "anthropic": {
         "claude-sonnet-4-6": "Claude Sonnet 4.6",

--- a/textlingo-desktop/src/locales/zh.json
+++ b/textlingo-desktop/src/locales/zh.json
@@ -387,6 +387,7 @@
         "moonshot-v1-8k": "Moonshot v1 8k"
       },
       "meta": {
+        "rl-muse-spark-1-2-playground": "Muse Spark 1.2 Playground",
         "muse-spark-1.2": "Muse Spark 1.2",
         "muse-spark-1.1": "Muse Spark 1.1",
         "muse-spark-1.2-contributor": "Muse Spark 1.2 Contributor"

--- a/textlingo-desktop/src/locales/zh.json
+++ b/textlingo-desktop/src/locales/zh.json
@@ -324,6 +324,7 @@
       "moonshot": "月之暗面 (Kimi)",
       "moonshot-cn": "月之暗面 (Kimi 中国版)",
       "moonshot-global": "Moonshot AI (Kimi 国际版)",
+      "meta": "Meta AI",
       "anthropic": "Anthropic (Claude)"
     },
     "baseUrl": "服务地址",
@@ -384,6 +385,11 @@
         "moonshot-v1-128k": "Moonshot v1 128k",
         "moonshot-v1-32k": "Moonshot v1 32k",
         "moonshot-v1-8k": "Moonshot v1 8k"
+      },
+      "meta": {
+        "muse-spark-1.2": "Muse Spark 1.2",
+        "muse-spark-1.1": "Muse Spark 1.1",
+        "muse-spark-1.2-contributor": "Muse Spark 1.2 Contributor"
       },
       "anthropic": {
         "claude-sonnet-4-6": "Claude Sonnet 4.6",


### PR DESCRIPTION
## Summary

Adds Meta AI (Muse Spark) as an API provider using Meta’s OpenAI-compatible API at `https://api.meta.ai/v1`.

- Adds Meta provider configuration and localized labels
- Supports `/v1/chat/completions` and `/v1/models`
- Routes Meta through the existing OpenAI-compatible transport
- Supports Meta in both the standard AI service and agent/mind-map runtime
- Uses `rl-muse-spark-1-2-playground` as the default model
- Adds a visible **Sync Models** action for Meta
- Keeps the displayed and saved model IDs consistent after syncing
- Prevents late Meta sync responses from overwriting another provider’s selection

## Validation

- `npm test` — 94 tests passed
- `npm run build` — passed